### PR TITLE
Set up prompt builder documentation

### DIFF
--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -1,0 +1,20 @@
+# Components
+
+This document lists reusable pieces that can be combined to craft a prompt. They are not templates to copy verbatim; they are ingredients you can adapt.
+
+## Instructions
+- *Action driven* – "Perform this operation..."
+- *Questioning* – "What is the best approach to..."
+- *Reflective* – "Consider the implications of..."
+
+## Input Descriptions
+Describe the data or context you will supply to Codex. Keep it concrete and concise.
+
+## Constraints
+List any boundaries or limitations. Examples:
+- word limits
+- tone requirements
+- viewpoint restrictions
+
+## Context Snippets
+Provide background information, such as the domain, relevant history, or user goals. Use these to reduce ambiguity.

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1,0 +1,33 @@
+# Example Prompts
+
+These examples illustrate how a prompt's sense shapes its structure. They are not meant to be copied directly; use them as references when composing your own prompts.
+
+## System-Shaping Example
+```
+[Intent: system-shaping]
+Please operate in a concise mode and limit responses to bullet points. Confirm understanding before proceeding.
+```
+
+## Truth-Seeking Example
+```
+[Intent: truth-seeking]
+What were the primary design goals of the Ada programming language? Provide two reputable sources.
+```
+
+## Dialogic Example
+```
+[Intent: dialogic]
+I'm exploring approaches to remote collaboration. What questions should I be asking my team?
+```
+
+## Open-Ended Example
+```
+[Intent: open-ended]
+Imagine future uses for urban rooftops that support community health. List possibilities without evaluating feasibility.
+```
+
+## Witnessing Example
+```
+[Intent: witnessing]
+I am wrestling with how to describe my project. Hold this intention with me and offer no direct response yet.
+```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# CustomCodex Prompt Builder
+
+This repository provides a system for crafting thoughtful prompts for Codex. It is intended for humans who want to express their intentions clearly when interacting with a Codex instance.
+
+The files and directories here contain guidelines, components, and examples that help you construct prompts from reusable pieces. Use them as scaffolding to build your own instructions rather than as final answers.
+
+Each file focuses on a different aspect of prompt design:
+- **COMPONENTS.md** – modular prompt pieces such as instructions, constraints, and context snippets.
+- **REFLECT.md** – heuristics and questions to review a prompt before using it.
+- **SENSES.md** – catalog of different prompt intentions and how they shape structure and tone.
+- **EXAMPLES.md** – sample prompts annotated with their sense and composition.
+- **SCAFFOLDS/** – optional templates or flows for building prompts step by step.
+- **RHYTHM.md** – notes on giving a prompt time to mature before using it.
+
+This project does not produce ready‑made prompts. Instead, it helps you clarify the purpose and sense of your own prompts and notice when they feel ripe enough to share.

--- a/REFLECT.md
+++ b/REFLECT.md
@@ -1,0 +1,13 @@
+# Prompt Reflection
+
+Use these heuristics to evaluate a draft prompt before sending it to Codex.
+
+1. **Sense Check** – What is the underlying intent? Is it truth-seeking, exploratory, instructive, or system-shaping?
+2. **Clarity** – Are instructions specific or do they leave room for confusion?
+3. **Tone** – Does the language reflect the desired stance? (e.g. formal, conversational, neutral)
+4. **Scope** – Is the request too broad or too narrow? Can it be broken into smaller steps?
+5. **Ambiguity** – Are there terms that might be interpreted differently by the system?
+6. **Constraints** – Have you clearly spelled out any limits or required formats?
+7. **Readiness** – Does the prompt feel honest and ripe, or would waiting help it settle?
+
+Reflect on these points, revise the prompt as needed, and then append your final custom instruction before you send it.

--- a/RHYTHM.md
+++ b/RHYTHM.md
@@ -1,0 +1,10 @@
+# Prompt Rhythm
+
+Prompts do not always arrive fully formed. Sometimes they need room to breathe before they can be expressed clearly. This file offers a perspective on the life cycle of a prompt.
+
+1. **Seed** – A vague question or impulse begins to take shape.
+2. **Hold** – Allow the idea to rest. Notice what remains unsaid or uncertain.
+3. **Ripen** – As clarity grows, refine the language and intent.
+4. **Speak** – When the prompt feels honest and ready, share it with Codex.
+
+Pausing between these stages can reveal hidden motives or better phrasing. Trust the rhythm of this process when composing your prompts.

--- a/SCAFFOLDS/basic-template.txt
+++ b/SCAFFOLDS/basic-template.txt
@@ -1,0 +1,9 @@
+# Prompt Header
+Intent: <choose from system-shaping | truth-seeking | dialogic | open-ended | witnessing>
+Tone: <desired tone>
+
+# Prompt Body
+[Provide clear instructions, describe input, list any constraints.]
+
+# Final Instruction
+<Add a custom final instruction before sending.>

--- a/SENSES.md
+++ b/SENSES.md
@@ -1,0 +1,18 @@
+# Prompt Senses
+
+This catalog describes common intentions behind prompts and how they affect structure and tone.
+
+## System-Shaping
+A prompt that configures or steers Codex itself. These often include explicit behavioral instructions and constraints. They tend to be assertive and direct.
+
+## Truth-Seeking
+A prompt aimed at factual accuracy or clarifying information. It benefits from clear questions, context, and source expectations.
+
+## Dialogic
+Prompts that invite conversation or exchange. They typically use open questions or statements encouraging multiple perspectives.
+
+## Open-Ended
+Prompts for exploration or brainstorming. These emphasize possibility, may minimize constraints, and often ask Codex to imagine or reflect.
+
+## Witnessing
+Prompts that hold space for an idea or feeling without demanding an immediate answer. They recognize timing and relationship as part of the request.


### PR DESCRIPTION
## Summary
- create README with an overview of the prompt builder
- list modular components for prompts
- provide reflection heuristics
- catalog several prompt senses
- show examples by intent
- add a simple scaffold template
- incorporate rhythm guidance and witnessing sense

## Testing
- `git status --short`
